### PR TITLE
Add i18n support (version 2.1)

### DIFF
--- a/create-settings.php
+++ b/create-settings.php
@@ -8,27 +8,27 @@
 
 	function star_cloudprnt_settings()
 	{
-		
-		add_settings_section("star_cloudprnt_setup_section", "CloudPRNT Setup", "star_cloudprnt_setup_section_info", "star_cloudprnt_setup");
-		add_settings_field("star-cloudprnt-select", "CloudPRNT", "star_cloudprnt_select_display", "star_cloudprnt_setup", "star_cloudprnt_setup_section");  
-		add_settings_field("star-cloudprnt-printer-select", "Selected Printer", "star_cloudprnt_printer_select_display", "star_cloudprnt_setup", "star_cloudprnt_setup_section"); 
-		
-		add_settings_field("star-cloudprnt-printer-encoding-select", "Text Encoding", "star_cloudprnt_printer_encoding_select_display", "star_cloudprnt_setup", "star_cloudprnt_setup_section");
 
-		add_settings_field("star-cloudprnt-trigger", "Printing Trigger", "star_cloudprnt_trigger_display", "star_cloudprnt_setup", "star_cloudprnt_setup_section");
+		add_settings_section("star_cloudprnt_setup_section", __("CloudPRNT Setup", "star-cloudprnt-for-woocommerce"), "star_cloudprnt_setup_section_info", "star_cloudprnt_setup");
+		add_settings_field("star-cloudprnt-select", __("CloudPRNT", "star-cloudprnt-for-woocommerce"), "star_cloudprnt_select_display", "star_cloudprnt_setup", "star_cloudprnt_setup_section");
+		add_settings_field("star-cloudprnt-printer-select", __("Selected Printer", "star-cloudprnt-for-woocommerce"), "star_cloudprnt_printer_select_display", "star_cloudprnt_setup", "star_cloudprnt_setup_section");
 
-		add_settings_field("star-cloudprnt-print-copies-input", "Copies", "star_cloudprnt_print_copies_input_display", "star_cloudprnt_setup", "star_cloudprnt_setup_section");  
-		
-		add_settings_field("star-cloudprnt-buzzer", "Buzzer", "star_cloudprnt_buzzer_display", "star_cloudprnt_setup", "star_cloudprnt_setup_section");
+		add_settings_field("star-cloudprnt-printer-encoding-select", __("Text Encoding", "star-cloudprnt-for-woocommerce"), "star_cloudprnt_printer_encoding_select_display", "star_cloudprnt_setup", "star_cloudprnt_setup_section");
 
-		add_settings_section("star_cloudprnt_design_section", "Print Job Design Options", "star_cloudprnt_design_header", "star_cloudprnt_setup");
-		add_settings_field("star-cloudprnt-header", "Header", "star_cloudPRNT_header_settings_display", "star_cloudprnt_setup", "star_cloudprnt_design_section");
-		add_settings_field("star-cloudprnt-items", "Item List", "star_cloudPRNT_item_settings_display", "star_cloudprnt_setup", "star_cloudprnt_design_section");
-		add_settings_field("star-cloudprnt-order-fields", "Additional Order Fields", "star_cloudPRNT_order_fields_display", "star_cloudprnt_setup", "star_cloudprnt_design_section");
-		add_settings_field("star-cloudprnt-logo", "Logo", "star_cloudPRNT_print_logo_display", "star_cloudprnt_setup", "star_cloudprnt_design_section");
+		add_settings_field("star-cloudprnt-trigger", __("Printing Trigger", "star-cloudprnt-for-woocommerce"), "star_cloudprnt_trigger_display", "star_cloudprnt_setup", "star_cloudprnt_setup_section");
+
+		add_settings_field("star-cloudprnt-print-copies-input", __("Copies", "star-cloudprnt-for-woocommerce"), "star_cloudprnt_print_copies_input_display", "star_cloudprnt_setup", "star_cloudprnt_setup_section");
+
+		add_settings_field("star-cloudprnt-buzzer", __("Buzzer", "star-cloudprnt-for-woocommerce"), "star_cloudprnt_buzzer_display", "star_cloudprnt_setup", "star_cloudprnt_setup_section");
+
+		add_settings_section("star_cloudprnt_design_section", __("Print Job Design Options", "star-cloudprnt-for-woocommerce"), "star_cloudprnt_design_header", "star_cloudprnt_setup");
+		add_settings_field("star-cloudprnt-header", __("Header", "star-cloudprnt-for-woocommerce"), "star_cloudPRNT_header_settings_display", "star_cloudprnt_setup", "star_cloudprnt_design_section");
+		add_settings_field("star-cloudprnt-items", __("Item List", "star-cloudprnt-for-woocommerce"), "star_cloudPRNT_item_settings_display", "star_cloudprnt_setup", "star_cloudprnt_design_section");
+		add_settings_field("star-cloudprnt-order-fields", __("Additional Order Fields", "star-cloudprnt-for-woocommerce"), "star_cloudPRNT_order_fields_display", "star_cloudprnt_setup", "star_cloudprnt_design_section");
+		add_settings_field("star-cloudprnt-logo", __("Logo", "star-cloudprnt-for-woocommerce"), "star_cloudPRNT_print_logo_display", "star_cloudprnt_setup", "star_cloudprnt_design_section");
 
 	}
-	
+
 	function star_cloudprnt_register_settings()
 	{
 		/* Attempt to set the default print job trigger to "status_processing" for new installs, but "thankyou" for sites that have
@@ -41,23 +41,23 @@
 
 		register_setting("star_cloudprnt_setup_section", "star-cloudprnt-select");
 		register_setting("star_cloudprnt_setup_section", "star-cloudprnt-printer-select");
-		
+
 		register_setting("star_cloudprnt_setup_section", "star-cloudprnt-printer-encoding-select");
 		register_setting("star_cloudprnt_setup_section", "star-cloudprnt-print-copies-input");
 
 		register_setting("star_cloudprnt_setup_section", "star-cloudprnt-trigger", array("default" => $trigger_default));
 
-		register_setting("star_cloudprnt_setup_section", "star-cloudprnt-print-header-title", array("default" => "ORDER NOTIFICATION"));
+		register_setting("star_cloudprnt_setup_section", "star-cloudprnt-print-header-title", array("default" => __("ORDER NOTIFICATION", 'star-cloudprnt-for-woocommerce')));
 
 		register_setting("star_cloudprnt_setup_section", "star-cloudprnt-print-items-print-id", array("default" => "on"));
 		register_setting("star_cloudprnt_setup_section", "star-cloudprnt-print-items-print-sku", array("default" => "off"));
 
-		register_setting("star_cloudprnt_setup_section", "star-cloudprnt-print-items-footer-message", array("default" => "All prices are inclusive of tax (if applicable)."));
+		register_setting("star_cloudprnt_setup_section", "star-cloudprnt-print-items-footer-message", array("default" => __("All prices are inclusive of tax (if applicable).", 'star-cloudprnt-for-woocommerce')));
 
 		register_setting("star_cloudprnt_setup_section", "star-cloudprnt-print-order-meta-cb");
 		register_setting("star_cloudprnt_setup_section", "star-cloudprnt-print-order-meta-reformat-keys", array("default" => "on"));
 		register_setting("star_cloudprnt_setup_section", "star-cloudprnt-print-order-meta-hidden", array("default" => "off"));
-		register_setting("star_cloudprnt_setup_section", "star-cloudprnt-print-order-meta-exclusions", array("default" => "is_vat_exempt, mailchimp_woocommerce_campaign_id, mailchimp_woocommerce_landing_site"));
+		register_setting("star_cloudprnt_setup_section", "star-cloudprnt-print-order-meta-exclusions", array("default" => __("is_vat_exempt, mailchimp_woocommerce_campaign_id, mailchimp_woocommerce_landing_site", 'star-cloudprnt-for-woocommerce')));
 
 		register_setting("star_cloudprnt_setup_section", "star-cloudprnt-print-logo-top-cb");
 		register_setting("star_cloudprnt_setup_section", "star-cloudprnt-print-logo-top-input");
@@ -71,12 +71,12 @@
 
 	function star_cloudprnt_menu_item()
 	{
-		add_submenu_page("options-general.php", "Star CloudPRNT for WooCommerce", "Star CloudPRNT for WooCommerce", "manage_options", "star-cloudprnt-settings-admin", "star_cloudprnt_page"); 
+		add_submenu_page("options-general.php", __("Star CloudPRNT for WooCommerce", 'star-cloudprnt-for-woocommerce'), "Star CloudPRNT for WooCommerce", "manage_options", "star-cloudprnt-settings-admin", "star_cloudprnt_page");
 	}
-	
+
 	function star_cloudprnt_setup_section_info()
 	{
-		print '<strong>Set your printer "Server URL" to:</strong><br>';
+		printf( '<strong>%s</strong><br>', esc_html__('Set your printer "Server URL" to:', 'star-cloudprnt-for-woocommerce') );
 		print plugins_url('cloudprnt/cloudprnt.php', __FILE__);
 	}
 
@@ -84,30 +84,30 @@
 	{
 	   ?>
 			<select name="star-cloudprnt-select">
-				<option value="disable" <?php selected(get_option('star-cloudprnt-select'), "disable"); ?>>DISABLE</option>
-				<option value="enable" <?php selected(get_option('star-cloudprnt-select'), "enable"); ?>>ENABLE</option>
+				<option value="disable" <?php selected(get_option('star-cloudprnt-select'), "disable"); ?>><?php esc_html_e('DISABLE', 'star-cloudprnt-for-woocommerce');?></option>
+				<option value="enable" <?php selected(get_option('star-cloudprnt-select'), "enable"); ?>><?php esc_html_e('ENABLE', 'star-cloudprnt-for-woocommerce');?></option>
 			</select>
 	   <?php
 	}
-	
-	
+
+
 	function star_cloudprnt_printer_encoding_select_display()
 	{
 	   ?>
 			<select name="star-cloudprnt-printer-encoding-select">
-				<option value="UTF-8" <?php selected(get_option('star-cloudprnt-printer-encoding-select'), "utf-8"); ?>>UTF-8</option>
-				<option value="1252" <?php selected(get_option('star-cloudprnt-printer-encoding-select'), "1252"); ?>>1252</option>
+                <option value="UTF-8" <?php selected(get_option('star-cloudprnt-printer-encoding-select'), "utf-8"); ?>><?php esc_html_e('UTF-8', 'star-cloudprnt-for-woocommerce');?></option>
+                <option value="1252" <?php selected(get_option('star-cloudprnt-printer-encoding-select'), "1252"); ?>><?php esc_html_e('1252', 'star-cloudprnt-for-woocommerce');?></option>
 			</select>
-			<label>UTF-8 mode is recommended for mC-Print or TSP650II printer models.</label>
+			<label><?php esc_html_e('UTF-8 mode is recommended for mC-Print or TSP650II printer models.', 'star-cloudprnt-for-woocommerce');?></label>
 	   <?php
 	}
-	
+
 	function star_cloudprnt_print_copies_input_display()
 	{
 		$copies=get_option("star-cloudprnt-print-copies-input");
 		$copies = intval($copies);
 		if($copies < 1) $copies = 1;
-		
+
 		?>
 			<input type="number" name="star-cloudprnt-print-copies-input" value="<?php echo $copies; ?>" min=1 max=10>
 		<?php
@@ -116,7 +116,7 @@
 	function star_cloudprnt_printer_select_display()
 	{
 		$printerList = star_cloudprnt_get_printer_list();
-		if (empty($printerList)) echo '<select name="star-cloudprnt-printer-select" disabled><option value="none">No printer found</option></select>';
+		if (empty($printerList)) echo '<select name="star-cloudprnt-printer-select" disabled><option value="none">'.esc_html__('No printer found', 'star-cloudprnt-for-woocommerce').'</option></select>';
 		else
 		{
 			$selectedPrinter = "";
@@ -137,29 +137,29 @@
 				if (get_option('star-cloudprnt-printer-select') == $printer['name']) $selectedPrinter = $printer['printerMAC'];
 			}
 			echo '</select>';
-			
-			echo '<a href="javascript: void(0);" onclick="star_cloudprnt_load_printer_settings()" style="margin-left: 10px">Edit</a>';
-			
+
+			echo '<a href="javascript: void(0);" onclick="star_cloudprnt_load_printer_settings()" style="margin-left: 10px">'.esc_html__('Edit', 'star-cloudprnt-for-woocommerce').'</a>';
+
 		}
 	}
-	
-	function star_cloudprnt_trigger_display()  
+
+	function star_cloudprnt_trigger_display()
 	{
 		?>
 			<input type="radio" name="star-cloudprnt-trigger" value="status_processing" <?php checked(get_option('star-cloudprnt-trigger'), 'status_processing', true) ?>>
-			<label>When an order is assigned the "processing" status (recommended for most sites)</label><br>
+			<label><?php esc_html_e('When an order is assigned the "processing" status (recommended for most sites)', 'star-cloudprnt-for-woocommerce');?></label><br>
 			<input type="radio" name="star-cloudprnt-trigger" value="status_completed" <?php checked(get_option('star-cloudprnt-trigger'), 'status_completed', true) ?>>
-			<label>When an order is assigned the "completed" status</label><br>
+			<label><?php esc_html_e('When an order is assigned the "completed" status', 'star-cloudprnt-for-woocommerce');?></label><br>
 			<input type="radio" name="star-cloudprnt-trigger" value="status_on-hold" <?php checked(get_option('star-cloudprnt-trigger'), 'status_on-hold', true) ?>>
-			<label>When an order is assigned the "on hold" status</label><br>
+			<label><?php esc_html_e('When an order is assigned the "on hold" status', 'star-cloudprnt-for-woocommerce');?></label><br>
 			<input type="radio" name="star-cloudprnt-trigger" value="thankyou" <?php checked(get_option('star-cloudprnt-trigger'), 'thankyou', true) ?>>
-			<label>When WooCommerce "Thank You" message is displayed (<span class="star_cp_caution">&#x26a0;</span> legacy option, not recommended)</label><br>
+			<label><?php printf('%s<span class="star_cp_caution">&#x26a0;</span> %s', esc_html__('When WooCommerce "Thank You" message is displayed (', 'star-cloudprnt-for-woocommerce'), esc_html__('legacy option, not recommended)', 'star-cloudprnt-for-woocommerce'));?></label><br>
 			<input type="radio" name="star-cloudprnt-trigger" value="none" <?php checked(get_option('star-cloudprnt-trigger'), 'none', true) ?>>
-			<label>Disable automatic printing</label><br>
+			<label><?php esc_html_e('Disable automatic printing', 'star-cloudprnt-for-woocommerce');?></label><br>
 		<?php
 	}
 
-	
+
 	function star_cloudprnt_design_header()
 	{
 		?>
@@ -169,7 +169,7 @@
 	function star_cloudPRNT_header_settings_display()
 	{
 		?>
-			<label>Receipt Title</label><br/>
+			<label><?php esc_html_e('Receipt Title', 'star-cloudprnt-for-woocommerce');?></label><br/>
 			<input type="text" name="star-cloudprnt-print-header-title" size=60 value="<?php echo get_option('star-cloudprnt-print-header-title') ?>">
 		<?php
 	}
@@ -178,13 +178,13 @@
 	{
 		?>
 			<input type="checkbox" name="star-cloudprnt-print-items-print-id" value="on" <?php checked(get_option('star-cloudprnt-print-items-print-id'), 'on', true) ?> >
-			<label>Include Item ID</label><br/>
+			<label><?php esc_html_e('Include Item ID', 'star-cloudprnt-for-woocommerce');?></label><br/>
 
 			<input type="checkbox" name="star-cloudprnt-print-items-print-sku" value="on" <?php checked(get_option('star-cloudprnt-print-items-print-sku'), 'on', true) ?> >
-			<label>Include Item SKU</label><br/>
+			<label><?php esc_html_e('Include Item SKU', 'star-cloudprnt-for-woocommerce');?></label><br/>
 
 			<br/>
-			<label>Item list footer message</label><br/>
+			<label><?php esc_html_e('Item list footer message', 'star-cloudprnt-for-woocommerce');?></label><br/>
 			<textarea type="text" name="star-cloudprnt-print-items-footer-message" cols=60 rows=4><?php echo get_option('star-cloudprnt-print-items-footer-message') ?></textarea>
 		<?php
 	}
@@ -194,15 +194,15 @@
 	{
 		?>
 			<input type="checkbox" name="star-cloudprnt-print-order-meta-cb" value="on" <?php checked(get_option('star-cloudprnt-print-order-meta-cb'), 'on', true) ?> >
-			<label>Print additional order meta-data, such as custom fields.</label>
+			<label><?php esc_html_e('Print additional order meta-data, such as custom fields.', 'star-cloudprnt-for-woocommerce');?></label>
 			<div style="padding-left: 7mm">
 				<input type="checkbox" name="star-cloudprnt-print-order-meta-reformat-keys" value="on" <?php checked(get_option('star-cloudprnt-print-order-meta-reformat-keys'), 'on', true) ?> >
-				<label>Re-format key names (e.g. print "delivery_time" as "Delivery Time")</label><br/>
+				<label><?php esc_html_e('Re-format key names (e.g. print "delivery_time" as "Delivery Time")', 'star-cloudprnt-for-woocommerce');?></label><br/>
 				<input type="checkbox" name="star-cloudprnt-print-order-meta-hidden" value="on" <?php checked(get_option('star-cloudprnt-print-order-meta-hidden'), 'on', true) ?> >
-				<label>Include hidden fields</label><br/>
-				<br/><label>Exclude items with these key names (',' separated)</label><br/>
+				<label><?php esc_html_e('Include hidden fields', 'star-cloudprnt-for-woocommerce');?></label><br/>
+				<br/><label><?php esc_html_e("Exclude items with these key names (',' separated)", 'star-cloudprnt-for-woocommerce');?></label><br/>
 				<input type="text" name="star-cloudprnt-print-order-meta-exclusions" size=60 value="<?php echo get_option('star-cloudprnt-print-order-meta-exclusions') ?>">
-				
+
 			</div>
 		<?php
 	}
@@ -212,26 +212,28 @@
 		$top_option_value = '01';
 		$top_disabled = (get_option('star-cloudprnt-print-logo-top-cb') === 'on') ? "" : " disabled";
 		if (get_option('star-cloudprnt-print-logo-top-input')) $top_option_value = esc_attr(get_option('star-cloudprnt-print-logo-top-input'));
-		
+
 		$end_option_value = '01';
 		$end_disabled = (get_option('star-cloudprnt-print-logo-bottom-cb') === 'on') ? "" : " disabled";
 		if (get_option('star-cloudprnt-print-logo-bottom-input')) $end_option_value = esc_attr(get_option('star-cloudprnt-print-logo-bottom-input'));
-		
+
 		?>
 			<!--<label>Top of page:</label> -->
 			<input type="checkbox" name="star-cloudprnt-print-logo-top-cb" <?= checked(get_option('star-cloudprnt-print-logo-top-cb'), 'on', false); ?> onclick='document.getElementById("star-cloudprnt-top-logo-input").disabled = !this.checked;'>
-			<label>Print at top of page</label>
+			<label><?php esc_html_e('Print at top of page', 'star-cloudprnt-for-woocommerce');?></label>
 			<input type="text" style="width: 15mm;" id="star-cloudprnt-top-logo-input" name="star-cloudprnt-print-logo-top-input" value="<?= $top_option_value ?>" <?= $top_disabled ?> >
-			<label>Keycode</label><br/>
-			
+			<label><?php esc_html_e('Keycode', 'star-cloudprnt-for-woocommerce');?></label><br/>
+
 			<!--<label>End of page:</label> -->
 			<input type="checkbox" name="star-cloudprnt-print-logo-bottom-cb" <?= checked(get_option('star-cloudprnt-print-logo-bottom-cb'), 'on', false); ?> onclick='document.getElementById("star-cloudprnt-bottom-logo-input").disabled = !this.checked;'>
-			<label>Print at end of page</label>
+			<label><?php esc_html_e('Print at end of page', 'star-cloudprnt-for-woocommerce');?></label>
 			<input type="text" style="width: 15mm;" id="star-cloudprnt-bottom-logo-input" name="star-cloudprnt-print-logo-bottom-input" value="<?= $end_option_value ?>" <?= $end_disabled ?> >
-			<label>Keycode</label><br/>
-			<p><strong>Note:</strong> logos should be written to printer FlashROM memory, using a suitable tool, such as the
-		   StarPRNT Software for Windows, which can be downloaded from the <a href="http://starmicronics.com/support/Default.aspx">Star global downlad site</p>
-			
+			<label><?php esc_html_e('Keycode', 'star-cloudprnt-for-woocommerce');?></label><br/>
+			<p><?php sprintf('<strong>%s</strong>%s<a href="http://starmicronics.com/support/Default.aspx">%s</a>',
+                    esc_html__('Note:', 'star-cloudprnt-for-woocommerce'),
+                    esc_html__('logos should be written to printer FlashROM memory, using a suitable tool, such as the StarPRNT Software for Windows, which can be downloaded from the', 'star-cloudprnt-for-woocommerce'),
+                    esc_html__('Star global downlad site', 'star-cloudprnt-for-woocommerce')); ?></p>
+
 		<?php
 	}
 
@@ -239,9 +241,9 @@
 	{
 		?>
 			<input type="checkbox" name="star-cloudprnt-buzzer-start" value="on" <?php checked(get_option('star-cloudprnt-buzzer-start'), 'on', true) ?> >
-			<label>Sound  external buzzer before printing</label><br/>
+			<label><?php esc_html_e('Sound  external buzzer before printing', 'star-cloudprnt-for-woocommerce');?></label><br/>
 			<input type="checkbox" name="star-cloudprnt-buzzer-end" value="on" <?php checked(get_option('star-cloudprnt-buzzer-end'), 'on', true) ?> >
-			<label>Sound  external buzzer after printing</label><br/>
+			<label><?php esc_html_e('Sound  external buzzer after printing', 'star-cloudprnt-for-woocommerce');?></label><br/>
 		<?php
 	}
 
@@ -262,7 +264,7 @@
 					color: orange;
 					font-size: larger;
 					font-weight: bolder;
-				}, 
+				},
 			</style>
 		<?php
 
@@ -270,15 +272,15 @@
 
 		echo '<div class="wrap">';
 			echo '<img src="'.plugins_url('images/logo.png', __FILE__).'">';
-				echo '<h1>Star CloudPRNT for WooCommerce Settings</h1>';
+				echo sprintf( '<h1>%s</h1>', esc_html__('Star CloudPRNT for WooCommerce Settings', 'star-cloudprnt-for-woocommerce') );
 				echo '<h2>Version ' . $plugin_data['Version'] . '</h2>';
-				
+
 				if (!star_cloudprnt_is_woo_activated())
 				{
-					echo '<br><span style="color: red"><span class="dashicons dashicons-no"></span>Warning: Unable to detect WooCommerce plugin.<br/>This can sometimes occur, if the plugin has been installed to a custom folder. If you are certain that WooCommerce is installed and functioning, then you can safely ignore this warning</span>';
+					echo '<br><span style="color: red"><span class="dashicons dashicons-no"></span>' . esc_html__('Warning: Unable to detect WooCommerce plugin.', 'star-cloudprnt-for-woocommerce') . '<br/>' . esc_html__('This can sometimes occur, if the plugin has been installed to a custom folder. If you are certain that WooCommerce is installed and functioning, then you can safely ignore this warning', 'star-cloudprnt-for-woocommerce') . '</span>';
 				}
-		
-				if (isset($_GET['printersettings'])) 
+
+				if (isset($_GET['printersettings']))
 				{
 					if (isset($_GET['npn'])) star_cloudprnt_change_printer_name();
 					else if (isset($_GET['cq'])) star_cloudprnt_clear_printer_queue();
@@ -287,11 +289,11 @@
 					else star_cloudprnt_show_printer_settings_page();
 				}
 				else star_cloudprnt_show_settings_page();
-					
-					
+
+
 		echo '</div>';
 	}
-	
+
 	function star_cloudprnt_create_settings_page()
 	{
 		add_action("admin_init", "star_cloudprnt_settings");

--- a/order-handler.inc.php
+++ b/order-handler.inc.php
@@ -6,7 +6,7 @@
 
   mb_internal_encoding('utf-8');
 	mb_regex_encoding("UTF-8");
-	
+
   function star_mb_str_pad($str, $pad_len, $pad_str = ' ', $dir = STR_PAD_RIGHT) {
     $str_len = mb_strlen($str);
     $pad_str_len = mb_strlen($pad_str);
@@ -16,7 +16,7 @@
     if (!$pad_len || !$pad_str_len || $pad_len <= $str_len) {
         return $str;
     }
-   
+
     $result = null;
     $repeat = ceil($str_len - $pad_str_len + $pad_len);
     if ($dir == STR_PAD_RIGHT) {
@@ -32,7 +32,7 @@
                   	. $str
                     . mb_substr(str_repeat($pad_str, $repeat), 0, ceil($length));
     }
-   
+
     return $result;
 	}
 
@@ -45,7 +45,7 @@
   function star_cloudprnt_get_column_separated_data($columns, $max_chars)
 	{
 		$total_columns = count($columns);
-		
+
 		if ($total_columns == 0) return "";
 		if ($total_columns == 1) return $columns[0];
 		if ($total_columns == 2)
@@ -56,7 +56,7 @@
 			if ($total_whitespace < 0) return "";
 			return $columns[0].str_repeat(" ", $total_whitespace).$columns[1];
 		}
-		
+
 		$total_characters = 0;
 		foreach ($columns as $column)
 		{
@@ -72,15 +72,15 @@
 			$result .= $columns[$i].str_repeat(" ", $space_width);
 		}
 		$result .= $columns[$total_columns-1];
-		
+
 		return $result;
   }
-  
+
   // Retrieve order notes text
   function star_cloudprnt_get_wc_order_notes($order_id){
 		//make sure it's a number
 		$order_id = intval($order_id);
-		//get the post 
+		//get the post
 		$post = get_post($order_id);
 		//if there's no post, return as error
 		if (!$post) return false;
@@ -96,7 +96,7 @@
 
 		return star_cloudprnt_filter_html($symbol);
 	}
-	
+
 	// Format a float value as a currency string
 	function star_cloudprnt_format_currency($value)
 	{
@@ -108,7 +108,7 @@
 	function star_cloudprnt_filter_html($data)
 	{
 		/* Filter known html key words, convert to printer appropriate commands and encoding */
-		
+
 		$encoding = get_option('star-cloudprnt-printer-encoding-select');
 
 		$phpenc = "UTF-8";
@@ -129,7 +129,7 @@
 	function star_cloudprnt_trigger_print($order_id)
 	{
 
-		$extension = STAR_CLOUDPRNT_SPOOL_FILE_FORMAT;	
+		$extension = STAR_CLOUDPRNT_SPOOL_FILE_FORMAT;
 		$print_width_dots = STAR_CLOUDPRNT_PAPER_SIZE_THREE_INCH;			// Fall back default, just in case the printer has not declared it's print width for some reason
 
 		// $selectedPrinterMac = "";
@@ -137,7 +137,7 @@
 		$printerList = star_cloudprnt_get_printer_list();
 		if (!empty($printerList))
 		{
-		
+
 			foreach ($printerList as $printer)
 			{
 				if (get_option('star-cloudprnt-printer-select') == $printer['name'])
@@ -152,12 +152,12 @@
 			if (sizeof($selectedPrinter) == 0) {
 				$selectedPrinter = $printerList[0];
 			}
-			
+
 			/* Decide best printer emulation and print width as far as possible
 			   NOTE: this is not the ideal way, but suits the existing
 			   code structure. Will be reviewed.
 			   */
-			
+
 			$encodings = $selectedPrinter['Encodings'];
 			$columns = STAR_CLOUDPRNT_MAX_CHARACTERS_THREE_INCH;
 			if (strpos($encodings, "application/vnd.star.line;") !== false) {
@@ -180,12 +180,12 @@
 				$extension = "spt";
 			} else if (strpos($encodings, "text/plain") !== false) {
 				$extension = "txt";
-			} 
-			
+			}
+
 			if ($selectedPrinter['ClientType'] == "Star mC-Print2") {
 				$columns = STAR_CLOUDPRNT_MAX_CHARACTERS_TWO_INCH;
 			}
-			
+
 			$selectedPrinter['format'] = $extension;
 			$selectedPrinter['columns'] = $columns;
 
@@ -195,18 +195,18 @@
 
 			// Store the final determined
 			$selectedPrinter['printWidth'] = $print_width_dots;
-			
+
 			$file = STAR_CLOUDPRNT_PRINTER_PENDING_SAVE_PATH.star_cloudprnt_get_os_path("/order_".$order_id."_".time().".".$extension);
 
 			if ($selectedPrinter !== "") star_cloudprnt_print_order_summary($selectedPrinter, $file, $order_id);
 		}
 	}
-	
+
 	// Insert the "Reprint vis Star CloudPRNT" order action to the list
 	function star_cloudprnt_order_reprint_action( $actions ) {
 		global $theorder;
 
-		$actions['star_cloudprnt_reprint_action'] = __( 'Print via Star CloudPRNT', 'my-textdomain' );
+		$actions['star_cloudprnt_reprint_action'] = __( 'Print via Star CloudPRNT', 'star-cloudprnt-for-woocommerce' );
 		return $actions;
 	}
 
@@ -221,7 +221,7 @@
 	{
     add_meta_box(
         'woocommerce-order-star-cloudprnt',
-        __( 'Star CloudPRNT' ),
+        __( 'Star CloudPRNT', 'star-cloudprnt-for-woocommerce' ),
         'star_cloudprnt_order_meta_box_content',
         'shop_order',
         'side',
@@ -251,7 +251,7 @@
 
 			</script>
 
-			<a href="javascript: star_cloudprnt_trigger();"><span><span class="dashicons dashicons-printer"></span> Print with Star CloudPRNT</span></a>
+			<a href="javascript: star_cloudprnt_trigger();"><span><span class="dashicons dashicons-printer"></span> <?php esc_html_e('Print with Star CloudPRNT', 'star-cloudprnt-for-woocommerce'); ?></span></a>
       <span id="star_cp_job_sent" style="display:none"><span class="dashicons dashicons-yes"></span></span>
 
 		<?php
@@ -280,7 +280,7 @@
 
 			// Register handler for the order action reprint request
 			add_action('woocommerce_order_action_star_cloudprnt_reprint_action', 'star_cloudprnt_reprint', 1, 1 );
-			
+
 
 			// Register the automatic order printing trigger, depending on config
 			$trigger = get_option('star-cloudprnt-trigger');

--- a/order-handler.php
+++ b/order-handler.php
@@ -5,19 +5,19 @@
 	 *
 	 *  All functions here are responsible for generating the printed receipt, by analysing a WC_Order
 	 *  object to obtain information about the order, and calling printer functions on the $printer object.
-	 * 
+	 *
 	*/
 
 	// Always include this - it is responsible for registering the necessary hooks to trigger print jobs
 	include_once('order-handler.inc.php');
 
 
-	// Return the text data used as a separator/horizontal line on the page 
+	// Return the text data used as a separator/horizontal line on the page
 	function star_cloudprnt_get_separator($max_chars)
 	{
 		return str_repeat('_', $max_chars);
 	}
-	
+
 	// Generate the receipt header
 	function star_cloudprnt_print_receipt_header(&$printer, &$order)
 	{
@@ -78,7 +78,7 @@
 		};
 
 		$banner = array();
-		$banner["left"] = "Order #".$order_number;			// Order number text to print
+		$banner["left"] = sprintf(__("Order #%d", 'star-cloudprnt-for-woocommerce'), $order_number);			// Order number text to print
 		$banner["right"] = date("{$date_format} {$time_format}", current_time('timestamp'));			// TIme of printing text
 
 		$banner = apply_filters('smcpfw_sub_header_banner', $banner, $order);
@@ -92,22 +92,22 @@
 		}
 
 		// Print header info area
-		$pw("Order Status", $order->get_status());
+		$pw(__("Order Status", 'star-cloudprnt-for-woocommerce'), $order->get_status());
 		$order_date = date("{$date_format} {$time_format}", $order->get_date_created()->getOffsetTimestamp());
-		$pw("Order Date", $order_date);	
+		$pw(__("Order Date", 'star-cloudprnt-for-woocommerce'), $order_date);
 
 		$printer->add_new_line(1);
 		if (isset($shipping_items['name']))
-			$pw("Shipping Method", $shipping_items['name']);
-		
-		$pw("Payment Method", $order->get_payment_method_title());
+			$pw(__("Shipping Method", 'star-cloudprnt-for-woocommerce'), $shipping_items['name']);
+
+		$pw(__("Payment Method", 'star-cloudprnt-for-woocommerce'), $order->get_payment_method_title());
 	}
 
 	// Print heading above the items list
 	function star_cloudprnt_print_items_header(&$printer, &$order)
 	{
 		$printer->add_new_line(1);
-		$printer->add_two_columns_text_line('ITEM', 'TOTAL');
+		$printer->add_two_columns_text_line(__('ITEM', 'star-cloudprnt-for-woocommerce'), __('TOTAL', 'star-cloudprnt-for-woocommerce'));
 		$printer->add_text_line(star_cloudprnt_get_separator($printer->get_text_columns()));
 	}
 
@@ -127,7 +127,7 @@
 			$alt_name = $product->get_attribute( 'star_cp_print_name' );				// Custom attribute can be used to override the product name on receipt
 
 			$item_qty = $item_data->get_quantity();
-			
+
 			$item_total_price = floatval(wc_get_order_item_meta($item_id, "_line_total", true))
 				+floatval(wc_get_order_item_meta($item_id, "_line_tax", true));
 
@@ -135,7 +135,7 @@
 			//$item_total_price = floatval(wc_get_order_item_meta($item_id, "_line_total", true));
 
 			$item_price = $product->get_price();
-			
+
 			if ($variation_id != 0)
 			{
 				$product_variation = new WC_Product_Variation( $variation_id );
@@ -143,36 +143,36 @@
 				$sku = $product_variation->get_sku();
 				$item_price = $product_variation->get_price();
 			}
-			
+
 			if ($alt_name != "")
 				$product_name = $alt_name;
-			
+
 			$formatted_item_price = star_cloudprnt_format_currency($item_price);
 			$formatted_total_price = star_cloudprnt_format_currency($item_total_price);
-			
+
 			$product_info = "";
 			if(get_option('star-cloudprnt-print-items-print-id') == "on")
-				$product_info .= " - ID: " . $product_id;
+				$product_info .= sprintf(__(" - ID: %d", 'star-cloudprnt-for-woocommerce'), $product_id);
 			if(get_option('star-cloudprnt-print-items-print-sku') == "on" && (! empty($sku)))
-				$product_info .= " - SKU: " . $sku;
+				$product_info .= sprintf(__(" - SKU: %s", 'star-cloudprnt-for-woocommerce'), $sku);
 
-			// $product_info .= " Tax Class: " . $item_data->get_tax_class();
+			// $product_info .= sprintf(__(" Tax Class: %s", 'star-cloudprnt-for-woocommerce'), $item_data->get_tax_class());
 
 			$product_line = star_cloudprnt_filter_html($product_name . $product_info);
 
 			$printer->set_text_emphasized();
 			$printer->add_word_wrapped_text_line($product_line);
 			$printer->cancel_text_emphasized();
-			
+
 			$meta = $item_data->get_formatted_meta_data("_", TRUE);
 
 			foreach ($meta as $meta_key => $meta_item)
 			{
-				$printer->add_word_wrapped_text_line(star_cloudprnt_filter_html(" ".$meta_item->display_key.": ".$meta_item->display_value));
+				$printer->add_word_wrapped_text_line(star_cloudprnt_filter_html(" ".$meta_item->display_key.__(": ", 'star-cloudprnt-for-woocommerce').$meta_item->display_value));
 			}
-			
+
 			$printer->add_two_columns_text_line(
-				$item_qty." x Cost: ".$formatted_item_price,
+				$item_qty.__(" x Cost: ", 'star-cloudprnt-for-woocommerce').$formatted_item_price,
 				$formatted_total_price);
 		}
 	}
@@ -198,9 +198,9 @@
 			elseif ($coupon_type == "percent")
 				$coupon_value = '-' . $coupon->get_amount() . '%';
 
-			$printer->add_two_columns_text_line("Coupon: " . $coupon_code, $coupon_value);
+			$printer->add_two_columns_text_line(sprintf(__("Coupon: %s", 'star-cloudprnt-for-woocommerce'), $coupon_code), $coupon_value);
 		}
-		
+
 	}
 
 	// Print totals
@@ -219,7 +219,7 @@
 		$printer->set_text_right_align();
 
 		if($order->get_total_discount() > 0)
-			$ft("DISCOUNT", -$order->get_discount_total());
+			$ft(__("DISCOUNT", 'star-cloudprnt-for-woocommerce'), -$order->get_discount_total());
 
 		// Print any fees attached to the order
 		$fees = $order->get_fees();
@@ -230,11 +230,11 @@
 		$taxes = $order->get_tax_totals();
 		foreach ($taxes as $tax)
 		{
-			$ft("TAX ({$tax->label})", $tax->amount);
+			$ft(sprintf(__("TAX (%s)", 'star-cloudprnt-for-woocommerce'), $tax->label), $tax->amount);
 		}
-		$ft("TAX TOTAL", $order->get_total_tax());
+		$ft(__("TAX TOTAL", 'star-cloudprnt-for-woocommerce'), $order->get_total_tax());
 
-		$ft("TOTAL", $order->get_total());
+		$ft(__("TOTAL", 'star-cloudprnt-for-woocommerce'), $order->get_total());
 
 		$printer->set_text_left_align();
 	}
@@ -249,16 +249,16 @@
 
 		$printer->add_new_line(1);
 		$printer->add_word_wrapped_text_line($item_footer_message);
-		
+
 	}
-	
+
 	// Generate the Additional Order info section, which prints extra fields that are attached to the order
 	// Such as delivery times etc.
 	function star_cloudprnt_print_additional_order_info(&$printer, &$order)
 	{
 		if(get_option('star-cloudprnt-print-order-meta-cb') != "on")
 			return;
-		
+
 		$meta_data = $order->get_meta_data();
 
 		$is_printed = false;
@@ -283,7 +283,7 @@
 				$is_printed = true;
 				$printer->add_new_line(1);
 				$printer->set_text_emphasized();
-				$printer->add_text_line("Additional Order Information");
+				$printer->add_text_line(__("Additional Order Information", 'star-cloudprnt-for-woocommerce'));
 				$printer->cancel_text_emphasized();
 			}
 
@@ -293,7 +293,7 @@
 
 			$printer->add_word_wrapped_text_line(star_cloudprnt_filter_html($formatted_key) . ": " . star_cloudprnt_filter_html($item_data["value"]));
 		}
-		
+
 	}
 
 	// Print the address section - currently this prints the shipping address if present, otherwise
@@ -318,18 +318,18 @@
 		$state = $gkv('_shipping_state');
 		$postcode = $gkv('_shipping_postcode');
 		$tel = $gkv('_billing_phone');
-		
+
 		$printer->add_new_line(1);
 
 		$printer->set_text_emphasized();
 		if ($a1 == '')
 		{
-			$printer->add_text_line("Billing Address:");
+			$printer->add_text_line(__("Billing Address:", 'star-cloudprnt-for-woocommerce'));
 			$printer->cancel_text_emphasized();
 			$fname = $gkv('_billing_first_name');
 			$lname = $gkv('_billing_last_name');
 			$a1 = $gkv('_billing_address_1');
-		
+
 			$a2 = $gkv('_billing_address_2');
 			$city = $gkv('_billing_city');
 			$state = $gkv('_billing_state');
@@ -337,10 +337,10 @@
 		}
 		else
 		{
-			$printer->add_text_line("Shipping Address:");
+			$printer->add_text_line(__("Shipping Address:", 'star-cloudprnt-for-woocommerce'));
 			$printer->cancel_text_emphasized();
 		}
-		
+
 		$printer->add_text_line($fname." ".$lname);
 		$printer->add_text_line($a1);
 		if ($a2 != '') $printer->add_text_line($a2);
@@ -348,7 +348,7 @@
 		if ($state != '') $printer->add_text_line($state);
 		if ($postcode != '') $printer->add_text_line($postcode);
 
-		$printer->add_text_line("Tel: ".$tel);
+		$printer->add_text_line(sprintf(__("Tel: %s", 'star-cloudprnt-for-woocommerce'), $tel));
 	}
 
 	// Print info below items list
@@ -358,11 +358,11 @@
 
 		$printer->add_new_line(1);
 		$printer->set_text_emphasized();
-		$printer->add_text_line("Customer Provided Notes:");
+		$printer->add_text_line(__("Customer Provided Notes:", 'star-cloudprnt-for-woocommerce'));
 		$printer->cancel_text_emphasized();
-		
+
 		if(empty($notes))
-			$printer->add_text_line('None');
+			$printer->add_text_line(__("None", 'star-cloudprnt-for-woocommerce'));
 		else
 			$printer->add_word_wrapped_text_line($notes);
 	}
@@ -382,7 +382,7 @@
 		// Default receipt sections
 		$sections = array("header", "sub_header", "items_header", "items", "coupons", "item_totals", "items_footer", "order_info", "address", "notes", "footer", "end");
 		$sections = apply_filters('smcpfw_sections', $sections, $order);
-		
+
 		foreach ($sections as $section)
 		{
 			// Check for any pre_section text/data to be printed
@@ -440,7 +440,7 @@
 
 		// Get the correct object for building commands for the selected printer
 		$printer = star_cloudprnt_command_generator($selectedPrinter, $file);
-		
+
 		// Ask the printer to use the correct text encoding
 		$printer->set_codepage(get_option('star-cloudprnt-printer-encoding-select'));
 		$printer->clear_formatting();
@@ -464,7 +464,7 @@
 		// Get the number of copies from the settings
 		$copies=intval(get_option("star-cloudprnt-print-copies-input"));
 		if($copies < 1) $copies = 1;
-		
+
 		// Send the print job to the spooling folder, ready to be connected by the printer and printed.
 		$printer->printJob($copies);
 	}

--- a/printer-settings-page.php
+++ b/printer-settings-page.php
@@ -13,7 +13,7 @@
 		}
 		return $printerMac;
 	}
-	
+
 	function star_cloudprnt_change_printer_name()
 	{
 		$selectedPrinter = base64_decode($_GET['printersettings']);
@@ -38,18 +38,18 @@
 			header('location: ?page='.$_GET['page'].'&printersettings='.base64_encode($newPrinterName));
 		}
 	}
-	
+
 	function star_cloudprnt_clear_printer_queue()
 	{
 		$printerMac = star_cloudprnt_get_selected_printer_mac(base64_decode($_GET['printersettings']));
-		
+
 		if (isset($printerMac))
 		{
 			star_cloudprnt_queue_clear_list($printerMac);
 			header('location: ?page='.$_GET['page'].'&printersettings='.$_GET['printersettings']);
 		}
 	}
-	
+
 	function star_cloudprnt_clear_order_history()
 	{
 		$history_path = STAR_CLOUDPRNT_DATA_FOLDER_PATH.star_cloudprnt_get_os_path("/order_history.txt");
@@ -57,11 +57,11 @@
 		fclose($fh);
 		header('location: ?page='.$_GET['page'].'&printersettings='.$_GET['printersettings']);
 	}
-	
+
 	function star_cloudprnt_delete_printer()
 	{
 		$printerMac = star_cloudprnt_get_selected_printer_mac(base64_decode($_GET['printersettings']));
-		
+
 		if (isset($printerMac))
 		{
 			$printer = new Star_CloudPRNT_Printer($printerMac);
@@ -74,7 +74,7 @@
 	{
 		$selectedPrinter = base64_decode($_GET['printersettings']);
 		$printerList = star_cloudprnt_get_printer_list();
-		
+
 		$printerdata;
 		foreach ($printerList as $printer)
 		{
@@ -84,21 +84,21 @@
 				break;
 			}
 		}
-		
+
 		?>
-		
-		<h2>Printer Information</h2>
+
+        <h2><?php esc_html_e('Printer Information', 'star-cloudprnt-for-woocommerce'); ?></h2>
 			<script>
 				function showDiv() {
 					if (document.getElementById('editPrinterNameContainer').style.display == "block")
 					{
 						document.getElementById('editPrinterNameContainer').style.display = "none";
-						document.getElementById('changeNameLabel').innerHTML = "Rename";
+                        document.getElementById('changeNameLabel').innerHTML = "<?php esc_html_e('Rename', 'star-cloudprnt-for-woocommerce'); ?>";
 					}
 					else
 					{
 						document.getElementById('editPrinterNameContainer').style.display = "block";
-						document.getElementById('changeNameLabel').innerHTML = "Hide";
+                        document.getElementById('changeNameLabel').innerHTML = "<?php esc_html_e('Hide', 'star-cloudprnt-for-woocommerce'); ?>";
 					}
 				}
 				function savePrinterName()
@@ -108,38 +108,38 @@
 				}
 			</script>
 			<?php
-				$onlineString = '<span style="color: orange">Unknown</span>';
-				if ($printerdata['printerOnline']) $onlineString = '<span style="color: green">Connected</span>';
-				else $onlineString = '<span style="color: red">Not Connected</span>';
+				$onlineString = '<span style="color: orange">'.esc_html__('Unknown', 'star-cloudprnt-for-woocommerce').'</span>';
+				if ($printerdata['printerOnline']) $onlineString = '<span style="color: green">'.esc_html__('Connected', 'star-cloudprnt-for-woocommerce').'</span>';
+				else $onlineString = '<span style="color: red">'.esc_html__('Not Connected', 'star-cloudprnt-for-woocommerce').'</span>';
 				$httpStatus = str_replace("%", " ", $printerdata['statusCode']);
 				$httpStatus = str_replace(" 20", " ", $httpStatus);
-				
-				echo "<strong>Name:</strong> ".$printerdata['name'].' - <a id="changeNameLabel" href="javascript:void(0);" onclick=\'showDiv()\'>Rename</a><br>';
+
+				echo "<strong>".esc_html__('Name:', 'star-cloudprnt-for-woocommerce')."</strong> ".$printerdata['name'].' - <a id="changeNameLabel" href="javascript:void(0);" onclick=\'showDiv()\'>'.esc_html__('Rename', 'star-cloudprnt-for-woocommerce').'</a><br>';
 				echo '<div id="editPrinterNameContainer" style="display: none">';
 					echo '<input id="printerName" type="text" name="printer" id="nprinter" placeholder="'.$printerdata['name'].'" value="'.$printerdata['name'].'" autocomplete="off">';
-					echo '<a href="javascript: void(0);" onclick="savePrinterName()" style="padding-left: 10px">Save</a>';
+					echo '<a href="javascript: void(0);" onclick="savePrinterName()" style="padding-left: 10px">'.esc_html__('Save', 'star-cloudprnt-for-woocommerce').'</a>';
 				echo '</div>';
-				if (isset($_GET['errorCode']) && $_GET['errorCode'] == 1) echo '<script type="text/javascript">showDiv()</script><span style="color:red;">Error: The new printer name must be between 3 and 35 characters long.</span><br>';
-				echo "<strong>Poll Interval:</strong> ".$printerdata['GetPollInterval']."<br>";
-				echo "<strong>Connectivity:</strong> ".$onlineString."<br>";
-				echo "<strong>ASB Status Code:</strong> ".$printerdata['status']."<br>";
-				echo "<strong>HTTP Status Code:</strong> ".$httpStatus."<br>";
-				echo "<strong>Last Communication:</strong> ".date("D j M y - H:i:s", $printerdata['lastActive']);
+				if (isset($_GET['errorCode']) && $_GET['errorCode'] == 1) echo '<script type="text/javascript">showDiv()</script><span style="color:red;">'.esc_html__('Error: The new printer name must be between 3 and 35 characters long.', 'star-cloudprnt-for-woocommerce').'</span><br>';
+				echo "<strong>".esc_html__('Poll Interval:', 'star-cloudprnt-for-woocommerce')."</strong> ".$printerdata['GetPollInterval']."<br>";
+				echo "<strong>".esc_html__('Connectivity:', 'star-cloudprnt-for-woocommerce')."</strong> ".$onlineString."<br>";
+				echo "<strong>".esc_html__('ASB Status Code:', 'star-cloudprnt-for-woocommerce')."</strong> ".$printerdata['status']."<br>";
+				echo "<strong>".esc_html__('HTTP Status Code:', 'star-cloudprnt-for-woocommerce')."</strong> ".$httpStatus."<br>";
+				echo "<strong>".esc_html__('Last Communication:', 'star-cloudprnt-for-woocommerce')."</strong> ".date("D j M y - H:i:s", $printerdata['lastActive']);
 			?>
-			
-			<h2>Printer Identification</h2>
+
+			<h2><?php esc_html_e('Printer Identification', 'star-cloudprnt-for-woocommerce'); ?></h2>
 			<?php
-				echo "<strong>MAC Address:</strong> ".strtoupper($printerdata['printerMAC'])."<br>";
-				echo "<strong>IP Address:</strong> ".$printerdata['ipAddress'];
+				echo "<strong>".esc_html__('MAC Address:', 'star-cloudprnt-for-woocommerce')."</strong> ".strtoupper($printerdata['printerMAC'])."<br>";
+				echo "<strong>".esc_html__('IP Address:', 'star-cloudprnt-for-woocommerce')."</strong> ".$printerdata['ipAddress'];
 			?>
-			
-			<h2>Interface</h2>
+
+			<h2><?php esc_html_e('Interface', 'star-cloudprnt-for-woocommerce'); ?></h2>
 			<?php
-				echo "<strong>Client Type:</strong> ".$printerdata['ClientType']."<br>";
-				echo "<strong>Client Version:</strong> ".$printerdata['ClientVersion'];
+				echo "<strong>".esc_html__('Client Type:', 'star-cloudprnt-for-woocommerce')."</strong> ".$printerdata['ClientType']."<br>";
+				echo "<strong>".esc_html__('Client Version:', 'star-cloudprnt-for-woocommerce')."</strong> ".$printerdata['ClientVersion'];
 			?>
-			
-			<h2>Supported Encodings</h2>
+
+			<h2><?php esc_html_e('Supported Encodings', 'star-cloudprnt-for-woocommerce'); ?></h2>
 			<?php
 				$encodings = explode(';', $printerdata['Encodings']);
 				foreach ($encodings as $encoding)
@@ -147,18 +147,18 @@
 					echo $encoding."<br>";
 				}
 			?>
-			
-			<h2>Printer Queue</h2>
+
+			<h2><?php esc_html_e('Printer Queue', 'star-cloudprnt-for-woocommerce'); ?></h2>
 			<?php
 				$queueItems = star_cloudprnt_queue_get_queue_list($printerdata['printerMAC']);
-				if (empty($queueItems)) echo 'No items found in printer queue.<br>';
+				if (empty($queueItems)) echo esc_html__('No items found in printer queue.', 'star-cloudprnt-for-woocommerce').'<br>';
 				else
 				{
 					echo '<table>';
 					echo '<tr>';
-						echo '<th style="padding: 5px">Priority</th>';
-						echo '<th>Order ID</th>';
-						echo '<th>Queued On</th>';
+						echo '<th style="padding: 5px">'.esc_html__('Priority', 'star-cloudprnt-for-woocommerce').'</th>';
+						echo '<th>'.esc_html__('Order ID', 'star-cloudprnt-for-woocommerce').'</th>';
+						echo '<th>'.esc_html__('Queued On', 'star-cloudprnt-for-woocommerce').'</th>';
 					echo '</tr>';
 						foreach ($queueItems as $queueNumber=>$item)
 						{
@@ -172,25 +172,25 @@
 							echo '</tr>';
 						}
 					echo '</table>';
-					
+
 					echo '<br><button class="button button-primary" onclick="location.href=\'?page='.$_GET['page']
-							.'&printersettings='.$_GET['printersettings'].'&cq\'">Clear Queue</button>';
+							.'&printersettings='.$_GET['printersettings'].'&cq\'">'.esc_html__('Clear Queue', 'star-cloudprnt-for-woocommerce').'</button>';
 				}
-			
+
 			?>
-			
-			<h2>Printed Order History</h2>
+
+			<h2><?php esc_html_e('Printed Order History', 'star-cloudprnt-for-woocommerce'); ?></h2>
 			<?php
 				$orderHistory = star_cloudprnt_queue_get_order_history();
-				if (empty($orderHistory)) echo 'No printed previous orders have been logged.<br>';
+				if (empty($orderHistory)) echo esc_html__('No printed previous orders have been logged.', 'star-cloudprnt-for-woocommerce').'<br>';
 				else
 				{
 					echo '<table>';
 					echo '<tr>';
-						echo '<th style="padding: 5px">Order ID</th>';
-						echo '<th>Copy Count</th>';
-						echo '<th>Queued On</th>';
-						echo '<th>Printed On</th>';
+						echo '<th style="padding: 5px">'.esc_html__('Order ID', 'star-cloudprnt-for-woocommerce').'</th>';
+						echo '<th>'.esc_html__('Copy Count', 'star-cloudprnt-for-woocommerce').'</th>';
+						echo '<th>'.esc_html__('Queued On', 'star-cloudprnt-for-woocommerce').'</th>';
+						echo '<th>'.esc_html__('Printed On', 'star-cloudprnt-for-woocommerce').'</th>';
 					echo '</tr>';
 						foreach ($orderHistory as $item)
 						{
@@ -199,7 +199,7 @@
 							$order_id = $exploded[2];
 							$queue_time = intval($exploded[3]);
 							$printed_time = intval($exploded[4]);
-							
+
 							echo '<tr>';
 								echo '<td style="text-align: center;">'.$order_id.'</td>';
 								echo '<td style="text-align: center;">'.$copy.'</td>';
@@ -208,20 +208,20 @@
 							echo '</tr>';
 						}
 					echo '</table>';
-					
+
 					echo '<br><button class="button button-primary" onclick="location.href=\'?page='.$_GET['page']
-							.'&printersettings='.$_GET['printersettings'].'&coh\'">Clear Order History</button>';
+							.'&printersettings='.$_GET['printersettings'].'&coh\'">'.esc_html__('Clear Order History', 'star-cloudprnt-for-woocommerce').'</button>';
 				}
 			?>
-			
-			<h2>Delete Printer</h2>
+
+			<h2><?php esc_html_e('Delete Printer', 'star-cloudprnt-for-woocommerce'); ?></h2>
 			<?php
-				if ($printerdata['printerOnline']) echo '<span style="color: red"><span class="dashicons dashicons-no"></span>You cannot delete the printer whilst it is connected</span>';
+				if ($printerdata['printerOnline']) echo '<span style="color: red"><span class="dashicons dashicons-no"></span>'.esc_html__('You cannot delete the printer whilst it is connected', 'star-cloudprnt-for-woocommerce').'</span>';
 				else echo '<button class="button button-primary" onclick="location.href=\'?page='.$_GET['page']
-						.'&printersettings='.$_GET['printersettings'].'&dp\'">Delete Printer</button>';
+						.'&printersettings='.$_GET['printersettings'].'&dp\'">'.esc_html__('Delete Printer', 'star-cloudprnt-for-woocommerce').'</button>';
 			?>
-			
-			<br><br><a href="?page=<?php echo $_GET['page']; ?>">Return to previous page</a>
+
+			<br><br><a href="?page=<?php echo $_GET['page']; ?>"><?php esc_html_e('Return to previous page', 'star-cloudprnt-for-woocommerce'); ?></a>
 		<?php
 	}
 ?>

--- a/star-cloudprnt-for-woocommerce.php
+++ b/star-cloudprnt-for-woocommerce.php
@@ -10,11 +10,12 @@
 	 * Tested up to: 5.7
 	 * WC requires at least: 4.0
 	 * WC tested up to: 5.2
+	 * Text Domain: star-cloudprnt-for-woocommerce
 	 */
-	 
+
 	// Block direct access to this script
 	if (!defined( 'ABSPATH' )) exit;
-	
+
 	// Include printer files
 	if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') include_once(plugin_dir_path(__FILE__).'cloudprnt\\printer.inc.php');
 	else include_once(plugin_dir_path(__FILE__).'cloudprnt/printer.inc.php');
@@ -24,23 +25,23 @@
 	include_once(plugin_dir_path(__FILE__).star_cloudprnt_get_os_path('cloudprnt/printer_star_line.inc.php'));
 	include_once(plugin_dir_path(__FILE__).star_cloudprnt_get_os_path('cloudprnt/printer_text_plain.inc.php'));
 	include_once(plugin_dir_path(__FILE__).star_cloudprnt_get_os_path('cloudprnt/printer_star_prnt.inc.php'));
-	
+
 	// Include plugin page settings and woo commerce hooks
 	include_once(plugin_dir_path(__FILE__).star_cloudprnt_get_os_path('create-settings.php'));
 	include_once(plugin_dir_path(__FILE__).star_cloudprnt_get_os_path('order-handler.php'));
-	
+
 	star_cloudprnt_register_settings();
-	
+
 	// Run page setup and woo commerce hooks
 	star_cloudprnt_create_settings_page();
 	star_cloudprnt_setup_order_handler();
 
 	// Add a settings link on the plugins page
-	function my_plugin_settings_link($links) { 
-		$settings_link = '<a href="options-general.php?page=star-cloudprnt-settings-admin">Settings</a>'; 
-		array_unshift($links, $settings_link); 
-		return $links; 
+	function my_plugin_settings_link($links) {
+		$settings_link = '<a href="options-general.php?page=star-cloudprnt-settings-admin">'.esc_html__('Settings', 'star-cloudprnt-for-woocommerce').'</a>';
+		array_unshift($links, $settings_link);
+		return $links;
 	}
-	$plugin = plugin_basename(__FILE__); 
+	$plugin = plugin_basename(__FILE__);
 	add_filter("plugin_action_links_$plugin", 'my_plugin_settings_link' );
 ?>


### PR DESCRIPTION
I'd like to use this plugin in Japanese, so I added support for internationalization.

Once this has been merged, we'll be able to translate it on the following WordPress page.
https://translate.wordpress.org/projects/wp-plugins/star-cloudprnt-for-woocommerce/

By the way, the following is an example of Japanese translation in my development environment.

![i18n-sample1](https://user-images.githubusercontent.com/84167/117277530-f0052e00-ae9a-11eb-8514-6b430b0ef230.png)

![i18n-sample2](https://user-images.githubusercontent.com/84167/117277377-cba95180-ae9a-11eb-9f95-fdb27a0e1702.png)

![i18n-sample3](https://user-images.githubusercontent.com/84167/117277389-cea44200-ae9a-11eb-876a-63bf3cdb736e.jpg)

